### PR TITLE
Fix usage of `FinalizationRegistry` in js-double-drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "macro", "example"]
 
 [package]
 name = "ffi-gen"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Call rust from any language."
 repository = "https://github.com/cloudpeers/ffi-gen"

--- a/example/js/bindings.mjs
+++ b/example/js/bindings.mjs
@@ -67,7 +67,7 @@ class Box {
     this.ptr = ptr;
     this.dropped = false;
     this.moved = false;
-    dropRegistry.register(this, destructor);
+    dropRegistry.register(this, destructor, this);
     this.destructor = destructor;
   }
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -326,7 +326,7 @@ impl JsGenerator {
                     this.ptr = ptr;
                     this.dropped = false;
                     this.moved = false;
-                    dropRegistry.register(this, destructor);
+                    dropRegistry.register(this, destructor, this);
                     this.destructor = destructor;
                 }
 


### PR DESCRIPTION
The third optional parameter of the `FinalizationRegistry` is a token to be
used for unregistering the object. If omitted, the object can't be 
unregistered [0].

[0]:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register